### PR TITLE
Crash fixes

### DIFF
--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/MediaGalleryFragment.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/MediaGalleryFragment.kt
@@ -42,7 +42,7 @@ class MediaGalleryFragment : Fragment(), MediaCellListener {
             Observer {
                 it ?: return@Observer
                 mediaGalleryAdapter = MediaGalleryAdapter(
-                    viewModel.getCurrentMediaCursor(),
+                    viewModel.getCurrentMediaCursor() ?: return@Observer,
                     viewModel.getSelectedMediaCellDisplayModels(),
                     this@MediaGalleryFragment,
                     viewModel.getChoiceSpec().mimeTypes,

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/cell/MediaCellDisplayModel.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/cell/MediaCellDisplayModel.kt
@@ -14,6 +14,6 @@ data class MediaCellDisplayModel(
     val mediaUri: Uri,
     val isChecked: Boolean = false,
     val isEnabled: Boolean,
-    val bucketDisplayName: String,
+    val bucketDisplayName: String?,
     val mimeType: MimeType?
 ) : Parcelable


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalStateException
bucketDisplayName must not be null
```
`MediaGalleryAdapter.java line 117`
Fix: 25909b3


```
Fatal Exception: java.lang.NullPointerException
Attempt to invoke interface method 'long android.database.Cursor.getLong(int)' on a null object reference
com.kinnerapriyap.sugar.mediagallery.media.MediaGalleryAdapter.onBindViewHolder
```
`MediaGalleryAdapter.java line 105,110,111`
Fix: 616ed9f