### PR TITLE
Fix crashes

### DIFF
--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilActivity.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilActivity.kt
@@ -21,7 +21,6 @@ import com.kinnerapriyap.sugar.databinding.ActivityShergilBinding
 import com.kinnerapriyap.sugar.mediagallery.album.MediaGalleryAlbumSpinnerAdapter
 import com.kinnerapriyap.sugar.mediagallery.album.toBucketDisplayName
 import com.kinnerapriyap.sugar.resultlauncher.ResultLauncherHandler
-import java.util.ArrayList
 
 internal class ShergilActivity :
     AppCompatActivity(),

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilActivity.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilActivity.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import android.widget.AdapterView
 import android.widget.Toast
@@ -193,7 +195,9 @@ internal class ShergilActivity :
             viewModel.resetCameraCaptureUri()
             observer?.cameraCapture(viewModel.getCameraCaptureUri())
         } else {
-            navController.navigate(NavGraphDirections.actionGlobalCameraFragment())
+            Handler(Looper.getMainLooper()).post {
+                navController.navigate(NavGraphDirections.actionGlobalCameraFragment())
+            }
         }
     }
 

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilViewModel.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilViewModel.kt
@@ -18,6 +18,7 @@ import com.kinnerapriyap.sugar.mediagallery.MediaGalleryHandler.Companion.ALL_AL
 import com.kinnerapriyap.sugar.mediagallery.album.MediaGalleryAlbum
 import com.kinnerapriyap.sugar.mediagallery.cell.MediaCellDisplayModel
 import com.kinnerapriyap.sugar.mediagallery.cell.MediaCellUpdateModel
+import com.kinnerapriyap.sugar.mediagallery.media.DEFAULT_ID
 import com.kinnerapriyap.sugar.mediagallery.media.MediaGalleryCursorWrapper
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
@@ -95,19 +96,27 @@ class ShergilViewModel(application: Application) : AndroidViewModel(application)
 
     fun setMediaChecked(displayModel: MediaCellDisplayModel) {
         val selected = selectedMediaCellDisplayModels.value ?: mutableListOf()
-        if (selected.any { it.id == displayModel.id }) {
-            selected.removeAll { it.id == displayModel.id }
-        } else {
-            if (isSelectedOverMax()) {
+        when {
+            displayModel.id == DEFAULT_ID -> {
                 errorMessage.value =
-                    getApplication<Application>().resources.getString(
-                        R.string.max_selectable_error,
-                        choiceSpec.maxSelectable
-                    )
+                    getApplication<Application>().resources.getString(R.string.invalid_id)
                 return
             }
-            if (!allowMultipleSelection()) selected.removeAll(selected)
-            selected.add(displayModel.copy(isChecked = true))
+            selected.any { it.id == displayModel.id } -> {
+                selected.removeAll { it.id == displayModel.id }
+            }
+            else -> {
+                if (isSelectedOverMax()) {
+                    errorMessage.value =
+                        getApplication<Application>().resources.getString(
+                            R.string.max_selectable_error,
+                            choiceSpec.maxSelectable
+                        )
+                    return
+                }
+                if (!allowMultipleSelection()) selected.removeAll(selected)
+                selected.add(displayModel.copy(isChecked = true))
+            }
         }
         updatedMediaCellPositions = Pair(displayModel.position, updatedMediaCellPositions.first)
         selectedMediaCellDisplayModels.value = selected

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilViewModel.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/ShergilViewModel.kt
@@ -7,6 +7,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
+import androidx.core.database.getStringOrNull
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -139,7 +140,7 @@ class ShergilViewModel(application: Application) : AndroidViewModel(application)
         while (!cursor.isAfterLast) {
             val bucketColumnIndex = cursor.getColumnIndex(MediaGalleryHandler.BUCKET_DISPLAY_NAME)
             if (bucketColumnIndex == -1) break
-            val name = cursor.getString(bucketColumnIndex)
+            val name = cursor.getStringOrNull(bucketColumnIndex)
             cursor.moveToNext()
             if (name == null || name == ALL_ALBUM_BUCKET_DISPLAY_NAME) continue
             else if (!addedNamesCount.contains(name)) {

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/choice/MimeType.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/choice/MimeType.kt
@@ -5,6 +5,7 @@ package com.kinnerapriyap.sugar.choice
  * Reference for MIME types supported by Android:
  * See [MediaFile.java](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/media/java/android/media/MediaFile.java/)
  */
+@Suppress("unused")
 enum class MimeType(val value: String) {
     // Images
     JPEG("image/jpeg"),
@@ -20,6 +21,6 @@ enum class MimeType(val value: String) {
         val IMAGES: List<MimeType> = values().toList()
 
         private val map = values().associateBy(MimeType::value)
-        fun fromValue(value: String): MimeType? = map[value]
+        fun fromValue(value: String?): MimeType? = map.getOrDefault(value, null)
     }
 }

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/MediaGalleryHandler.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/MediaGalleryHandler.kt
@@ -45,13 +45,13 @@ class MediaGalleryHandler(private val contentResolver: ContentResolver) {
         mimeTypes: List<MimeType>,
         showDisallowedMimeTypes: Boolean,
         allowCamera: Boolean
-    ): Cursor? {
+    ): Cursor {
         val extras = MatrixCursor(PROJECTION)
         if (allowCamera) {
             extras.addRow(
                 arrayOf(
                     CAMERA_CAPTURE_ID.toString(),
-                    MimeType.IMAGES,
+                    null,
                     ALL_ALBUM_BUCKET_DISPLAY_NAME
                 )
             )

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
@@ -89,13 +89,16 @@ class MediaGalleryAdapter(
      * so it is used to get the data
      */
     override fun onBindViewHolder(holder: MediaCellHolder, position: Int) {
-        if (mediaCursor?.moveToPosition(position) == false ||
-            !isDataValid ||
-            idColumnIndex == -1 ||
+        if (!mediaCursor.moveToPosition(position) || !isDataValid) {
+            throw IllegalStateException("onBind position:$position isDataValid:$isDataValid")
+        } else if (idColumnIndex == -1 ||
             bucketDisplayNameColumnIndex == -1 ||
             mimeTypeColumnIndex == -1
         ) {
-            throw IllegalStateException("onBind $position")
+            throw IllegalStateException(
+                "onBind invalid column index $idColumnIndex " +
+                        "$bucketDisplayNameColumnIndex $mimeTypeColumnIndex"
+            )
         }
 
         /**

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
@@ -22,6 +22,8 @@ import com.kinnerapriyap.sugar.mediagallery.cell.MediaCellDisplayModel
 import com.kinnerapriyap.sugar.mediagallery.cell.MediaCellUpdateModel
 import com.kinnerapriyap.sugar.mediagallery.cell.bindMediaUri
 
+const val DEFAULT_ID = -1L
+
 class MediaGalleryAdapter(
     private var mediaCursor: Cursor,
     private var selectedMediaCellDisplayModels: List<MediaCellDisplayModel>,
@@ -100,7 +102,7 @@ class MediaGalleryAdapter(
          * Get a URI representing the media item and
          * append the id from the projection column to the base URI
          */
-        val id = mediaCursor.getLongOrNull(idColumnIndex) ?: 0
+        val id = mediaCursor.getLongOrNull(idColumnIndex) ?: DEFAULT_ID
         val contentUri: Uri = ContentUris.withAppendedId(
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             id

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
@@ -34,8 +34,6 @@ class MediaGalleryAdapter(
     Filterable,
     MediaGalleryCursorFilterListener {
 
-    private var isDataValid = true
-
     var mediaCellUpdateModel: MediaCellUpdateModel =
         MediaCellUpdateModel(Pair(-1, -1), listOf())
         set(value) {
@@ -89,8 +87,8 @@ class MediaGalleryAdapter(
      * so it is used to get the data
      */
     override fun onBindViewHolder(holder: MediaCellHolder, position: Int) {
-        if (!mediaCursor.moveToPosition(position) || !isDataValid) {
-            throw IllegalStateException("onBind position:$position isDataValid:$isDataValid")
+        if (!mediaCursor.moveToPosition(position)) {
+            throw IllegalStateException("onBind position:$position")
         } else if (idColumnIndex == -1 ||
             bucketDisplayNameColumnIndex == -1 ||
             mimeTypeColumnIndex == -1
@@ -176,11 +174,10 @@ class MediaGalleryAdapter(
         if (newCursor === mediaCursor) return
         if (newCursor != null) {
             mediaCursor = newCursor
+            idColumnIndex =
+                mediaCursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+            notifyDataSetChanged()
         }
-        isDataValid = newCursor != null
-        idColumnIndex =
-            mediaCursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
-        notifyDataSetChanged()
     }
 
     override fun getFilter(): Filter = cursorFilter

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
@@ -119,11 +119,6 @@ class MediaGalleryAdapter(
 
     private fun isCameraCapture(id: Long) = id == CAMERA_CAPTURE_ID
 
-    override fun getItemId(position: Int): Long =
-        if (isDataValid && mediaCursor?.moveToPosition(position) == true) {
-            mediaCursor?.getLong(idColumnIndex) ?: 0
-        } else RecyclerView.NO_ID
-
     inner class MediaCellHolder(
         private val binding: ViewMediaCellBinding
     ) : RecyclerView.ViewHolder(binding.root) {

--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/mediagallery/media/MediaGalleryAdapter.kt
@@ -11,6 +11,8 @@ import android.widget.Filter
 import android.widget.FilterQueryProvider
 import android.widget.Filterable
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.database.getLongOrNull
+import androidx.core.database.getStringOrNull
 import androidx.recyclerview.widget.RecyclerView
 import com.kinnerapriyap.sugar.choice.MimeType
 import com.kinnerapriyap.sugar.databinding.ViewMediaCellBinding
@@ -58,13 +60,13 @@ class MediaGalleryAdapter(
      * getColumnIndexOrThrow is used since _ID column exists in [BaseColumns]
      */
     private var idColumnIndex =
-        mediaCursor?.getColumnIndexOrThrow(MediaStore.MediaColumns._ID) ?: -1
+        mediaCursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
 
     private val bucketDisplayNameColumnIndex =
-        mediaCursor?.getColumnIndex(MediaGalleryHandler.BUCKET_DISPLAY_NAME) ?: -1
+        mediaCursor.getColumnIndex(MediaGalleryHandler.BUCKET_DISPLAY_NAME)
 
     private val mimeTypeColumnIndex =
-        mediaCursor?.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE) ?: -1
+        mediaCursor.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE)
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -78,7 +80,7 @@ class MediaGalleryAdapter(
         return MediaCellHolder(binding)
     }
 
-    override fun getItemCount(): Int = mediaCursor?.count ?: 0
+    override fun getItemCount(): Int = mediaCursor.count
 
     /**
      * [mediaCursor] is moved to the correct position
@@ -98,13 +100,13 @@ class MediaGalleryAdapter(
          * Get a URI representing the media item and
          * append the id from the projection column to the base URI
          */
-        val id = mediaCursor.getLong(idColumnIndex)
+        val id = mediaCursor.getLongOrNull(idColumnIndex) ?: 0
         val contentUri: Uri = ContentUris.withAppendedId(
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             id
         )
-        val bucketDisplayName = mediaCursor.getString(bucketDisplayNameColumnIndex)
-        val mimeType = MimeType.fromValue(mediaCursor.getString(mimeTypeColumnIndex))
+        val bucketDisplayName = mediaCursor.getStringOrNull(bucketDisplayNameColumnIndex)
+        val mimeType = MimeType.fromValue(mediaCursor.getStringOrNull(mimeTypeColumnIndex))
         val displayModel = MediaCellDisplayModel(
             position = position,
             id = id,
@@ -172,7 +174,7 @@ class MediaGalleryAdapter(
         }
         isDataValid = newCursor != null
         idColumnIndex =
-            newCursor?.getColumnIndex(MediaStore.MediaColumns._ID) ?: -1
+            mediaCursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
         notifyDataSetChanged()
     }
 

--- a/sher-gil/src/main/res/values/strings.xml
+++ b/sher-gil/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="preview">Preview</string>
     <string name="gallery_image">Gallery image</string>
     <string name="max_selectable_error">You can only select up to %d media files</string>
+    <string name="invalid_id">This media file has an invalid id</string>
     <string name="take_photo">Take Photo</string>
     <string name="switch_camera">Switch camera</string>
     <string name="open_gallery">Open gallery</string>


### PR DESCRIPTION
```
com.kinnerapriyap.sugar.mediagallery.media.MediaGalleryAdapter.onBindViewHolder

Fatal Exception: java.lang.NullPointerException
Attempt to invoke interface method 'java.lang.String android.database.Cursor.getString(int)' on a null object reference
com.kinnerapriyap.sugar.mediagallery.media.MediaGalleryAdapter.onBindViewHolder
```

```
com.kinnerapriyap.sugar.ShergilViewModel.fetchAlbums

Fatal Exception: java.lang.NullPointerException
Attempt to invoke interface method 'java.lang.String android.database.Cursor.getString(int)' on a null object reference
com.kinnerapriyap.sugar.ShergilViewModel.fetchAlbums
```

For above two exceptions `getStringOrNull` is now used to avoid crashes and the fields are nullable

------

```
com.kinnerapriyap.sugar.mediagallery.media.MediaGalleryAdapter.onBindViewHolder

Fatal Exception: java.lang.IllegalStateException
onBind 0
```

This issue may happen when the cursor is null in the gallery adapter - changed to allow cursor to be non null all the time

------

Problem: Camera doesn't open for first time after giving permission
Solution 8c783f6 : By invoking a handler that would run in Main looper, onActivityResult -> onStart -> onResume runs before your code. If you do it directly in onActivityResult, then onStart hasn't run, the NavController says its state is restored, and it ignores your navigate call. 
