### PR TITLE
Fix NoSuchMethodError

### DIFF
--- a/sher-gil/src/main/java/com/kinnerapriyap/sugar/choice/MimeType.kt
+++ b/sher-gil/src/main/java/com/kinnerapriyap/sugar/choice/MimeType.kt
@@ -21,6 +21,6 @@ enum class MimeType(val value: String) {
         val IMAGES: List<MimeType> = values().toList()
 
         private val map = values().associateBy(MimeType::value)
-        fun fromValue(value: String?): MimeType? = map.getOrDefault(value, null)
+        fun fromValue(value: String?): MimeType? = map.get(value)
     }
 }


### PR DESCRIPTION
Problem: getOrDefault was added in API level 24 which causes it to crash in lower api devices. 
Solution: Use get instead of getOrDefault, default is null anyway

Closes #97 

[Ref to SO](https://stackoverflow.com/questions/58408832/nosuchmethoderror-no-interface-method-getordefaultljava-lang-objectljava-lang)